### PR TITLE
allow lower case

### DIFF
--- a/ticker.sh
+++ b/ticker.sh
@@ -36,6 +36,9 @@ query () {
 }
 
 for symbol in $(IFS=' '; echo "${SYMBOLS[*]}"); do
+  if $(type tr > /dev/null 2>&1); then
+    symbol=$(echo $symbol | tr 'a-z' 'A-Z')
+  fi
   marketState="$(query $symbol 'marketState')"
 
   if [ -z $marketState ]; then


### PR DESCRIPTION
This change just allows one to use either lower case or upper to specify the stock symbols.

![image](https://user-images.githubusercontent.com/11840428/54166407-82d0ec00-443b-11e9-9461-1a1b72a1ee99.png)

or

![image](https://user-images.githubusercontent.com/11840428/54166426-95e3bc00-443b-11e9-8d4d-3f8e13a599f0.png)

or a combination like

![image](https://user-images.githubusercontent.com/11840428/54166458-b1e75d80-443b-11e9-988c-542e3296c376.png)
