### PR TITLE
improvements

### DIFF
--- a/ticker.sh
+++ b/ticker.sh
@@ -20,10 +20,12 @@ FIELDS=(symbol marketState regularMarketPrice regularMarketChange regularMarketC
   preMarketPrice preMarketChange preMarketChangePercent postMarketPrice postMarketChange postMarketChangePercent)
 API_ENDPOINT="https://query1.finance.yahoo.com/v7/finance/quote?lang=en-US&region=US&corsDomain=finance.yahoo.com"
 
-: "${COLOR_BOLD:=\e[1;37m}"
-: "${COLOR_GREEN:=\e[32m}"
-: "${COLOR_RED:=\e[31m}"
-: "${COLOR_RESET:=\e[00m}"
+if [[ $TERM ]]; then
+  : "${COLOR_BOLD:=$(tput bold)}"
+  : "${COLOR_GREEN:=$(tput setaf 2)}"
+  : "${COLOR_RED:=$(tput setaf 1)}"
+  : "${COLOR_RESET:=$(tput sgr0)}"
+fi
 
 symbols=$(IFS=,; echo "${SYMBOLS[*]}")
 fields=$(IFS=,; echo "${FIELDS[*]}")

--- a/ticker.sh
+++ b/ticker.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-LANG=en_US.UTF-8
-LC_NUMERIC=en_US.UTF-8
+LANG=C
+LC_NUMERIC=C
 
 SYMBOLS=("$@")
 


### PR DESCRIPTION
This PR adds two improvements:

LANG=C instead of en_US.UTF-8, which pretty much means "no locale", what better describes what you want (I think)
use tput instead of hardcoded terminfo sequeces. This will support some exotic terminals, or no terminal at all (for example when writing into pipe or file). If you don't want to use the tput because of performance reasons, consider at least checking for $TERM before using terminfo color sequences