### PR TITLE
Don't try to print out information for an invalid symbol

### DIFF
--- a/ticker.sh
+++ b/ticker.sh
@@ -77,7 +77,9 @@ for symbol in $(IFS=' '; echo "${SYMBOLS[*]}"); do
     color=$COLOR_GREEN
   fi
 
-  printf "%-10s$COLOR_BOLD%8.2f$COLOR_RESET" $symbol $price
-  printf "$color%10.2f%12s$COLOR_RESET" $diff $(printf "(%.2f%%)" $percent)
-  printf " %s\n" "$nonRegularMarketSign"
+  if [ "$price" != "null" ]; then
+    printf "%-10s$COLOR_BOLD%8.2f$COLOR_RESET" $symbol $price
+    printf "$color%10.2f%12s$COLOR_RESET" $diff $(printf "(%.2f%%)" $percent)
+    printf " %s\n" "$nonRegularMarketSign"
+  fi
 done


### PR DESCRIPTION
If you put in an invalid symbol, you'll get hit with
```
./ticker.sh: line 80: printf: null: invalid number
```
when running the script. This commit prevents this from occurring.