### PR TITLE
Allow the symbols to be provided in a case-insensitive manner

### DIFF
--- a/ticker.sh
+++ b/ticker.sh
@@ -4,7 +4,7 @@ set -e
 LANG=C
 LC_NUMERIC=C
 
-SYMBOLS=("$@")
+SYMBOLS=("${@^^}")
 
 if ! $(type jq > /dev/null 2>&1); then
   echo "'jq' is not in the PATH. (See: https://stedolan.github.io/jq/)"

--- a/ticker.sh
+++ b/ticker.sh
@@ -77,7 +77,9 @@ for symbol in $(IFS=' '; echo "${SYMBOLS[*]}"); do
     color=$COLOR_GREEN
   fi
 
-  printf "%-10s$COLOR_BOLD%8.2f$COLOR_RESET" $symbol $price
-  printf "$color%10.2f%12s$COLOR_RESET" $diff $(printf "(%.2f%%)" $percent)
-  printf " %s\n" "$nonRegularMarketSign"
+  if [ "$price" != "null" ]; then
+    printf "%-10s$COLOR_BOLD%8.2f$COLOR_RESET" $symbol $price
+    printf "$color%10.2f%12s$COLOR_RESET" $diff $(printf "(%.2f%%)" $percent)
+    printf " %s\n" "$nonRegularMarketSign"
+  fi
 done


### PR DESCRIPTION
That way you can run `./ticker.sh aapl`, for instance. All symbols will be passed to the Yahoo Finance API in uppercase.