### PR TITLE
Automatically uppercase symbols

### DIFF
--- a/ticker.sh
+++ b/ticker.sh
@@ -38,6 +38,9 @@ query () {
 }
 
 for symbol in $(IFS=' '; echo "${SYMBOLS[*]}"); do
+  # Uppercase the symbol
+  symbol=${symbol^^}
+  
   marketState="$(query $symbol 'marketState')"
 
   if [ -z $marketState ]; then


### PR DESCRIPTION
It wasn't working when I typed 'ticker msft' but it worked when I typed 'ticker MSFT' so I changed it to automatically uppercase the symbol.