### PR TITLE
Making symbols case insensitive

### DIFF
--- a/ticker.sh
+++ b/ticker.sh
@@ -37,7 +37,7 @@ query () {
   echo $results | jq -r ".[] | select(.symbol == \"$1\") | .$2"
 }
 
-for symbol in $(IFS=' '; echo "${SYMBOLS[*]}"); do
+for symbol in $(IFS=' '; echo "${SYMBOLS[*]}" | tr '[:lower:]' '[:upper:]'); do
   marketState="$(query $symbol 'marketState')"
 
   if [ -z $marketState ]; then


### PR DESCRIPTION
I'm really lazy and didn't like typing "AAPL" instead of "aapl", so I added this bit to my local copy of the script to convert lowercase symbols to uppercase in the part where it matters.