### PR TITLE
Fix cookie setting by using a Yahoo Finance url that doesn't redirect to a consent page

### DIFF
--- a/ticker.sh
+++ b/ticker.sh
@@ -38,7 +38,8 @@ fields=$(IFS=,; echo "${FIELDS[*]}")
 [ ! -d "$SESSION_DIR" ] && mkdir -m 700 "$SESSION_DIR"
 
 preflight () {
-  curl --silent --output /dev/null --cookie-jar "$COOKIE_FILE" "https://finance.yahoo.com" \
+  # rather than "finance", use the "fc" subdomain which doesn't redirect to a consent page
+  curl --silent --output /dev/null --cookie-jar "$COOKIE_FILE" "https://fc.yahoo.com" \
   -H "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
   curl --silent -b "$COOKIE_FILE" "https://query1.finance.yahoo.com/v1/test/getcrumb" \
     > "$CRUMB_FILE"


### PR DESCRIPTION
Change the url used to get the cookie from `finance.yahoo.com` to `fc.yahoo.com`

This works around the fact that the "finance" subdomain redirects to a consent page (`https://guce.yahoo.com/consent`) and doesn't allow curl to properly set the cookie needed in subsequent steps

---
Fixes https://github.com/pstadler/ticker.sh/issues/37 and https://github.com/pstadler/ticker.sh/issues/33
A more detailed explanation of the problem and how I found this solution/workaround can be found at https://github.com/pstadler/ticker.sh/issues/37#issuecomment-1596979021